### PR TITLE
README: Indent using 2 spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Or install it yourself as:
 pool = Async::Pool::Controller.new(Async::Pool::Resource)
 
 pool.acquire do |resource|
-	# resource is implicitly released when exiting the block.
+  # resource is implicitly released when exiting the block.
 end
 
 resource = pool.acquire


### PR DESCRIPTION
In order for the usage documentation to present the least surprise to readers, it's here offered  with a GitHub-rendering "2 spaces" indentation.