### PR TITLE
Add missing licenses - MIT

### DIFF
--- a/async-pool.gemspec
+++ b/async-pool.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |spec|
 	spec.version       = Async::Pool::VERSION
 	spec.authors       = ["Samuel Williams"]
 	spec.email         = ["samuel.williams@oriontransfer.co.nz"]
+	spec.licenses      = ["MIT"]
 	
 	spec.summary       = "A Redis client library."
 	spec.homepage      = "https://github.com/socketry/async-pool"


### PR DESCRIPTION
It is better to add licenses explicitly in gemspec.

  % gem specification async-pool | \grep licenses
  licenses: []

ref. https://guides.rubygems.org/specification-reference/