### PR TITLE
Add a policy for managing pool allocation/behaviour.

### DIFF
--- a/test/async/pool/controller.rb
+++ b/test/async/pool/controller.rb
@@ -247,6 +247,14 @@ describe Async::Pool::Controller do
 			
 			expect(pool).not.to be(:active?)
 		end
+		
+		it "warns if closing while a resource is acquired" do
+			pool.acquire
+			
+			expect(Console.logger).to receive(:warn).and_return(nil)
+			
+			pool.close
+		end
 	end
 	
 	with '#to_s' do

--- a/test/async/pool/controller.rb
+++ b/test/async/pool/controller.rb
@@ -59,6 +59,36 @@ describe Async::Pool::Controller do
 		end
 	end
 	
+	with '#concurrency' do
+		it "adjust the concurrency limit" do
+			expect(pool.concurrency).to be == 1
+			
+			pool.concurrency = 2
+			expect(pool.concurrency).to be == 2
+		end
+	end
+	
+	with 'policy' do
+		let(:policy) {proc{|pool| pool.prune(2)}}
+		let(:pool) {subject.new(Async::Pool::Resource, policy: policy)}
+		
+		it "can execute a policy" do
+			resources = 4.times.map do
+				pool.acquire
+			end
+			
+			resources.each do |resource|
+				pool.release(resource)
+			end
+			
+			Async::Task.current.sleep(0.001)
+			
+			expect(pool.available).to have_attributes(
+				size: be == 2
+			)
+		end
+	end
+	
 	with '#close' do
 		it 'closes all resources' do
 			resource = pool.acquire
@@ -225,8 +255,9 @@ describe Async::Pool::Controller do
 		end
 		
 		it "can inspect a non-empty pool" do
-			pool.acquire
-			expect(pool.to_s).to be(:match?, "1/∞")
+			pool.acquire do
+				expect(pool.to_s).to be(:match?, "1/∞")
+			end
 		end
 	end
 	

--- a/test/async/pool/multiplex.rb
+++ b/test/async/pool/multiplex.rb
@@ -64,15 +64,15 @@ describe Async::Pool::Controller do
 		end
 		
 		it "puts the item back into the available list if it is reusable" do
-			object = pool.acquire
-			
-			mock(object) do |mock|
-				mock.replace(:reusable?) {true}
+			pool.acquire do |object|
+				mock(object) do |mock|
+					mock.replace(:reusable?) {true}
+				end
+				
+				pool.prune
+				
+				expect(pool.available).to be == [object]
 			end
-			
-			pool.prune
-			
-			expect(pool.available).to be == [object]
 		end
 	end
 end


### PR DESCRIPTION
For a long time, the behaviour of pools has been fairly inflexible. It's always been intended to add a swappable policy layer which controls pool minimum/maximum, etc.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
