### PR TITLE
Confirm that resource usage is still 0 before retiring

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Thomas Morgan <tm@iprog.com>

--- a/lib/async/pool/controller.rb
+++ b/lib/async/pool/controller.rb
@@ -156,10 +156,12 @@ module Async
 				
 				# It's okay for this to context switch:
 				unused.each do |resource|
-					if block_given?
-						yield resource
-					else
-						retire(resource)
+					if usage = @resources[resource] and usage.zero?
+						if block_given?
+							yield resource
+						else
+							retire(resource)
+						end
 					end
 					
 					break if @resources.size <= retain


### PR DESCRIPTION
This PR adds a secondary check that a resource is unused during pruning.

Per existing comments, retiring resources may cause context switches. When there are 2+ resources that are eligible for retiring, a context switch caused by retiring an earlier resource may also allow a later resource in the `unused` list to be reused. That may in turn cause a newly reused resource to be errantly retired and closed while in use.

## Types of Changes

- Bug fix.

## Contribution

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
