### PR TITLE
Add `Async::Pool::Controller#as_json` and related methods.

### DIFF
--- a/lib/async/pool/controller.rb
+++ b/lib/async/pool/controller.rb
@@ -44,6 +44,27 @@ module Async
 			# @attribute [Integer] The maximum number of resources that this pool can have at any given time.
 			attr_accessor :limit
 			
+			def to_s
+				if @resources.empty?
+					"\#<#{self.class}(#{usage_string})>"
+				else
+					"\#<#{self.class}(#{usage_string}) #{availability_summary.join(';')}>"
+				end
+			end
+			
+			def as_json(...)
+				{
+					limit: @limit,
+					concurrency: @guard.limit,
+					usage: @resources.size,
+					availability_summary: self.availability_summary,
+				}
+			end
+			
+			def to_json(...)
+				as_json.to_json(...)
+			end
+			
 			# @attribute [Integer] The maximum number of concurrent tasks that can be creating a new resource.
 			def concurrency
 				@guard.limit
@@ -133,14 +154,6 @@ module Async
 				@gardener&.stop
 			end
 			
-			def to_s
-				if @resources.empty?
-					"\#<#{self.class}(#{usage_string})>"
-				else
-					"\#<#{self.class}(#{usage_string}) #{availability_string}>"
-				end
-			end
-			
 			# Retire (and close) all unused resources. If a block is provided, it should implement the desired functionality for unused resources.
 			# @param retain [Integer] the minimum number of resources to retain.
 			# @yield resource [Resource] unused resources.
@@ -215,10 +228,10 @@ module Async
 				"#{@resources.size}/#{@limit || '∞'}"
 			end
 			
-			def availability_string
+			def availability_summary
 				@resources.collect do |resource, usage|
 					"#{usage}/#{resource.concurrency}#{resource.viable? ? nil : '*'}/#{resource.count}"
-				end.join(";")
+				end
 			end
 			
 			# def usage

--- a/test/async/pool/controller.rb
+++ b/test/async/pool/controller.rb
@@ -19,6 +19,21 @@ describe Async::Pool::Controller do
 		it 'is empty?' do
 			expect(pool).to be(:empty?)
 		end
+		
+		with '#as_json' do
+			it 'generates a JSON representation' do
+				expect(pool.as_json).to be == {
+					limit: nil,
+					concurrency: 1,
+					usage: 0,
+					availability_summary: []
+				}
+			end
+			
+			it "generates a JSON string" do
+				expect(JSON.dump(pool)).to be == pool.to_json
+			end
+		end
 	end
 	
 	with 'a limited pool' do


### PR DESCRIPTION
As a periphery fix for <https://github.com/socketry/async-http/issues/157>, introduce `as_json` for nicer output of pools in debug logs.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
