### PR TITLE
Graceful shutdown

### DIFF
--- a/lib/async/pool/controller.rb
+++ b/lib/async/pool/controller.rb
@@ -154,7 +154,7 @@ module Async
 				retire(resource) unless processed
 			end
 			
-			def drain
+			private def drain
 				# Enumerate all existing resources and retire them:
 				while resource = acquire_existing_resource
 					retire(resource)

--- a/lib/async/pool/controller.rb
+++ b/lib/async/pool/controller.rb
@@ -154,20 +154,18 @@ module Async
 				retire(resource) unless processed
 			end
 			
+			def drain
+				# Enumerate all existing resources and retire them:
+				while resource = acquire_existing_resource
+					retire(resource)
+				end
+			end
+			
 			# Close all resources in the pool.
 			def close
+				self.drain
+				
 				@available.clear
-				
-				while pair = @resources.shift
-					resource, usage = pair
-					
-					if usage > 0
-						Console.warn(self, resource: resource, usage: usage) {"Closing resource while still in use!"}
-					end
-					
-					resource.close
-				end
-				
 				@gardener&.stop
 			end
 			
@@ -223,6 +221,8 @@ module Async
 			
 			def start_gardener
 				return if @gardener
+				
+				@gardener = true
 				
 				Async(transient: true, annotation: "#{self.class} Gardener") do |task|
 					@gardener = task
@@ -319,7 +319,7 @@ module Async
 				resource = nil
 				
 				@guard.acquire do
-					resource = get_resource
+					resource = acquire_or_create_resource
 				end
 				
 				return resource
@@ -330,7 +330,24 @@ module Async
 			
 			private
 			
-			def get_resource
+			# Acquire an existing resource with zero usage.
+			# If there are resources that are in use, wait until they are released.
+			def acquire_existing_resource
+				while @resources.any?
+					@resources.each do |resource, usage|
+						if usage == 0
+							return resource
+						end
+					end
+					
+					@notification.wait
+				end
+				
+				# Only when the pool has been completely drained, return nil:
+				return nil
+			end
+			
+			def acquire_or_create_resource
 				while resource = @available.last
 					if usage = @resources[resource] and usage < resource.concurrency
 						if resource.viable?

--- a/test/async/pool/controller.rb
+++ b/test/async/pool/controller.rb
@@ -273,20 +273,18 @@ describe Async::Pool::Controller do
 			expect(pool).not.to be(:active?)
 		end
 		
-		it "warns if closing while a resource is acquired" do
+		it "waits for connection to be released" do
 			events = []
 			
+			events << :acquire
+			resource = pool.acquire
+			
 			child = Async do |task|
-				events << :acquire
-				resource = pool.acquire
-				
-				sleep 0.1
+				task.yield
 				
 				events << :release
 				pool.release(resource)
 			end
-			
-			sleep 0.1
 			
 			events << :close
 			pool.close


### PR DESCRIPTION
This introduces a more robust shutdown mechanism which handles connections being acquired during the draining phase.

Connections won't be closed until they are returned to the pool. This may result in a deadlock with code that is buggy. Previously it would force close and emit a warning.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
