### PR TITLE
Avoid draining pool in gardener cleanup

### DIFF
--- a/lib/async/pool/controller.rb
+++ b/lib/async/pool/controller.rb
@@ -260,7 +260,13 @@ module Async
 					end
 				ensure
 					@gardener = nil
-					self.close
+					
+					# During cancellation, busy resources will never be released,
+					# so force-retire everything instead of draining gracefully.
+					while (resource, _usage = @resources.first)
+						retire(resource)
+					end
+					@available.clear
 				end
 			end
 			

--- a/lib/async/pool/controller.rb
+++ b/lib/async/pool/controller.rb
@@ -260,7 +260,7 @@ module Async
 					end
 				ensure
 					@gardener = nil
-					self.close
+					self.terminate
 				end
 			end
 			
@@ -350,6 +350,23 @@ module Async
 			end
 			
 			private
+			
+			# Force-retire all resources immediately, including busy ones, without waiting for them to be released. Unlike {drain}, this never blocks, so it is safe to call during cancellation when busy resources will never be released.
+			def terminate
+				# Re-read `@resources.first` each iteration: `retire` -> `resource.close` can yield, so the set of resources may change mid-teardown.
+				while (resource, _usage = @resources.first)
+					begin
+						retire(resource)
+					rescue => error
+						Console.warn(self, "Failed to retire resource during teardown!", resource: resource, exception: error)
+						
+						# Ensure progress so the loop cannot spin forever on a resource that failed to retire:
+						@resources.delete(resource)
+					end
+				end
+				
+				@available.clear
+			end
 			
 			# Acquire an existing resource with zero usage.
 			# If there are resources that are in use, wait until they are released.

--- a/test/async/pool/controller.rb
+++ b/test/async/pool/controller.rb
@@ -301,6 +301,26 @@ describe Async::Pool::Controller do
 			
 			expect(events).to be == [:acquire, :close, :release, :closed]
 		end
+		
+		it "does not deadlock when Sync scope exits with unreleased resources" do
+			thread = Thread.new do
+				Sync do
+					policy = proc{|pool| pool.prune(0)}
+					pool = subject.new(Async::Pool::Resource, policy: policy)
+					
+					# Acquire a resource (starts the gardener) but don't release it
+					pool.acquire
+					
+					# Let gardener start and enter its wait loop
+					sleep 0.05
+				end
+			end
+			
+			result = thread.join(5)
+			thread.kill if result.nil?
+			
+			expect(result).not.to be_nil
+		end
 	end
 	
 	with "#to_s" do

--- a/test/async/pool/controller.rb
+++ b/test/async/pool/controller.rb
@@ -301,6 +301,59 @@ describe Async::Pool::Controller do
 			
 			expect(events).to be == [:acquire, :close, :release, :closed]
 		end
+		
+		it "does not deadlock when Sync scope exits with unreleased resources" do
+			thread = Thread.new do
+				Sync do
+					policy = proc{|pool| pool.prune(0)}
+					pool = subject.new(Async::Pool::Resource, policy: policy)
+					
+					# Acquire a resource (starts the gardener) but don't release it
+					pool.acquire
+					
+					# Let gardener start and enter its wait loop
+					sleep 0.05
+				end
+			end
+			
+			result = thread.join(5)
+			thread.kill if result.nil?
+			
+			expect(result).not.to be_nil
+		end
+		
+		it "force-retires all resources even if closing one raises" do
+			closed = []
+			
+			failing_resource = Class.new(Async::Pool::Resource) do
+				define_method(:close) do
+					closed << self
+					raise "Resource failed to close!"
+				end
+			end
+			
+			thread = Thread.new do
+				Sync do
+					policy = proc{|pool| pool.prune(0)}
+					pool = subject.new(failing_resource, policy: policy)
+					
+					# Acquire two resources (concurrency 1 each) but don't release them:
+					pool.acquire
+					pool.acquire
+					
+					# Let the gardener start and enter its wait loop:
+					sleep 0.05
+				end
+			end
+			
+			result = thread.join(5)
+			thread.kill if result.nil?
+			
+			# Teardown must force-retire every resource, even though closing the
+			# first one raises:
+			expect(result).not.to be_nil
+			expect(closed.size).to be == 2
+		end
 	end
 	
 	with "#to_s" do


### PR DESCRIPTION
When a `Sync` scope exits while the gardener is waiting, `Async::Cancel` interrupts `@condition.wait(@mutex)` inside `@mutex.synchronize`, producing a `ThreadError` warning. The gardener's ensure also called `self.close` → `drain`, which could block if resources are still acquired during teardown.

```
warn: Async::Task: Async::Pool::Controller Gardener
  Task may have ended with unhandled exception.
    ThreadError: Attempt to unlock a mutex which is not locked
    → async-pool-0.11.2/lib/async/pool/controller.rb:132 in `synchronize'
    Caused by Async::Cancel: Task was cancelled
```

The gardener's `ensure` now force-retires resources directly instead of calling `close`/`drain`.

### Types of Changes

- Bug fix.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
