### PR TITLE
Fix `ThreadError` when a fiber is cancelled while waiting on the pool condition

### DIFF
--- a/lib/async/pool/controller.rb
+++ b/lib/async/pool/controller.rb
@@ -129,14 +129,12 @@ module Async
 			# Wait until a pool resource has been freed.
 			# @deprecated Use {wait_until_free} instead.
 			def wait
-				@mutex.synchronize do
-					@condition.wait(@mutex)
-				end
+				wait_for_condition
 			end
 			
 			# Wait until the pool is not busy (no resources in use).
 			def wait_until_free
-				@mutex.synchronize do
+				synchronize do
 					if busy?
 						yield self if block_given?
 						
@@ -310,7 +308,7 @@ module Async
 			def wait_for_resource
 				# If we fail to create a resource (below), we will end up waiting for one to become resources.
 				until resource = available_resource
-					@mutex.synchronize{@condition.wait(@mutex)}
+					wait_for_condition
 				end
 				# Be careful not to context switch or fail here.
 				return resource
@@ -351,6 +349,28 @@ module Async
 			
 			private
 			
+			# Work around Ruby bug #20907, fixed in Ruby 3.4 and backported to Ruby 3.3.7 and Ruby 3.2.7:
+			# https://bugs.ruby-lang.org/issues/20907
+			# TODO: Remove this workaround after Ruby 3.3 support is dropped.
+			#
+			# Hold the mutex for the duration of the block, releasing it afterwards only if we still own it: {Thread::ConditionVariable#wait} does not reacquire the mutex if the calling fiber is cancelled while blocked, and unlocking it then raises `ThreadError` instead of propagating the cancellation.
+			#
+			# The `@condition.broadcast` call sites do not need this, as `broadcast` never releases the mutex.
+			def synchronize
+				@mutex.lock
+				
+				return yield
+			ensure
+				@mutex.unlock if @mutex.owned?
+			end
+			
+			# Wait until signalled that a resource has been released or retired.
+			def wait_for_condition
+				synchronize do
+					@condition.wait(@mutex)
+				end
+			end
+			
 			# Acquire an existing resource with zero usage.
 			# If there are resources that are in use, wait until they are released.
 			def acquire_existing_resource
@@ -360,7 +380,7 @@ module Async
 							return resource
 						end
 					end
-					@mutex.synchronize{@condition.wait(@mutex)}
+					wait_for_condition
 				end
 				# Only when the pool has been completely drained, return nil:
 				return nil

--- a/test/async/pool/controller.rb
+++ b/test/async/pool/controller.rb
@@ -486,4 +486,63 @@ describe Async::Pool::Controller do
 			pool.close
 		end
 	end
+	
+	with "cancellation while waiting" do
+		# `Thread::ConditionVariable#wait` releases the mutex while it blocks, and does not reacquire it if the waiting fiber is cancelled at that point. Releasing the mutex unconditionally afterwards raises `ThreadError: Attempt to unlock a mutex which is not locked`, which fails the task instead of cancelling it.
+		
+		it "cancels the gardener when closing the pool" do
+			# Allocating a resource starts the gardener, which then parks in `#wait`:
+			resource = pool.acquire
+			gardener = pool.instance_variable_get(:@gardener)
+			pool.release(resource)
+			
+			# This stops the gardener while it is waiting:
+			pool.close
+			
+			expect(gardener.wait).to be_nil
+		end
+		
+		with "a limited pool" do
+			let(:pool) {subject.new(Async::Pool::Resource, limit: 1)}
+			
+			it "cancels a task waiting to acquire a resource" do
+				resource = pool.acquire
+				
+				# The pool is at its limit, so this parks in `#wait_for_resource`:
+				waiting = Async{pool.acquire}
+				
+				waiting.stop
+				expect(waiting.wait).to be_nil
+				
+				pool.release(resource)
+				pool.close
+			end
+			
+			it "cancels a task waiting for the pool to be free" do
+				resource = pool.acquire
+				
+				# The pool is busy, so this parks in `#wait_until_free`:
+				waiting = Async{pool.wait_until_free}
+				
+				waiting.stop
+				expect(waiting.wait).to be_nil
+				
+				pool.release(resource)
+				pool.close
+			end
+			
+			it "cancels a task draining the pool" do
+				resource = pool.acquire
+				
+				# The resource is still in use, so this parks in `#acquire_existing_resource`:
+				closing = Async{pool.close}
+				
+				closing.stop
+				expect(closing.wait).to be_nil
+				
+				pool.release(resource)
+				pool.close
+			end
+		end
+	end
 end


### PR DESCRIPTION
## Summary
@ioquatix I noticed a lot of warning logs when upgrading our async gems. I believe this fixes it, would you mind taking a look? Thank you!

## Types of Changes

**Fix `ThreadError` when a fiber is cancelled while waiting on the pool condition.** `Thread::ConditionVariable#wait` releases the mutex while it blocks and does not reacquire it if the calling fiber is cancelled at that point, so `Mutex#synchronize`'s `ensure` raised `ThreadError: Attempt to unlock a mutex which is not locked`, displacing the `Async::Cancel` that should have propagated — and since `Async::HTTP::Client#close` closes its pool, every `Async::HTTP::Client.open { ... }` block logged a warning. All four condition waits are fixed, not just the gardener path in the backtrace (`#wait_for_resource` is on the acquire path, reachable under normal load via a request timeout). The mutex stays — it was introduced deliberately to make the `busy?`-check-and-wait in `#wait_until_free` atomic — and waits now go through a private `#synchronize` that only unlocks if the mutex is still owned; reacquiring instead would risk blocking and raising inside an `ensure` during cancellation. Public API unchanged. Four regression tests, one per wait site, all failing before the fix; suite green on Ruby 3.3.6 and 4.0.1; `Async::HTTP::Client.open { }` ×3 against a local server logs 3 `ThreadError`s before and 0 after.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
