### PR TITLE
Add regression test for cancelling pool gardener

### DIFF
--- a/test/async/pool/controller.rb
+++ b/test/async/pool/controller.rb
@@ -486,4 +486,19 @@ describe Async::Pool::Controller do
 			pool.close
 		end
 	end
+	
+	with "cancellation while waiting" do
+		it "cancels the gardener when closing the pool" do
+			# Regression test for https://bugs.ruby-lang.org/issues/20907.
+			# Allocating a resource starts the gardener, which then parks in `#wait`:
+			resource = pool.acquire
+			gardener = pool.instance_variable_get(:@gardener)
+			pool.release(resource)
+			
+			# This stops the gardener while it is waiting:
+			pool.close
+			
+			expect(gardener.wait).to be_nil
+		end
+	end
 end


### PR DESCRIPTION
## Summary

- Add a focused regression test for cancelling the pool gardener while it is blocked in `ConditionVariable#wait`.
- Assert the task outcome directly through `Task#wait`, which re-raises unexpected failures.

This extracts the regression test from #27 without carrying its library-level workaround. The underlying CRuby issue was fixed by https://github.com/ruby/ruby/pull/12158 and backported in Ruby 3.2.7 and Ruby 3.3.7.

## Testing

- `sus test/async/pool/controller.rb`
- 34 passed, 55 assertions